### PR TITLE
Lazily load CodePens only when code-bed component is visible

### DIFF
--- a/babel.config.json
+++ b/babel.config.json
@@ -9,5 +9,8 @@
         }
       ]
     ],
-    "plugins": ["@babel/plugin-proposal-class-properties"]
+    "plugins": [
+      "@babel/plugin-proposal-class-properties",
+      "@babel/plugin-proposal-optional-chaining"
+    ]
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -6061,9 +6061,9 @@
       }
     },
     "rollup": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.8.0.tgz",
-      "integrity": "sha512-hyjpreMA0BTNrO68o4wCtcktwYTK8o1UtauOqsPniwDGzN2PvNaKmwa/RHmjNHJMrt6ItY2C7XjpT7TDf6WmJw==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.8.1.tgz",
+      "integrity": "sha512-j4aRMIpr0LT5JogYQ0tkznjgKglI11fipTAUgpkhB14imdnlOfD30LDk1cRX2GWaFI0+i8ryW+k8+heVwcoyug==",
       "dev": true,
       "requires": {
         "fsevents": "~2.1.2"

--- a/package-lock.json
+++ b/package-lock.json
@@ -6061,9 +6061,9 @@
       }
     },
     "rollup": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.8.1.tgz",
-      "integrity": "sha512-j4aRMIpr0LT5JogYQ0tkznjgKglI11fipTAUgpkhB14imdnlOfD30LDk1cRX2GWaFI0+i8ryW+k8+heVwcoyug==",
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.8.2.tgz",
+      "integrity": "sha512-LRzMcB8V1M69pSvf6uCbR+W9OPCy5FuxcIwqioWg5RKidrrqKbzjJF9pEGXceaMVkbptNFZgIVJlUokCU0sfng==",
       "dev": true,
       "requires": {
         "fsevents": "~2.1.2"

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "jest": "26.0.1",
     "npm-run-all": "4.1.5",
     "rimraf": "3.0.2",
-    "rollup": "2.8.1",
+    "rollup": "2.8.2",
     "rollup-plugin-terser": "5.3.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "devDependencies": {
     "@babel/core": "7.9.6",
     "@babel/plugin-proposal-class-properties": "7.8.3",
+    "@babel/plugin-proposal-optional-chaining": "7.9.0",
     "@babel/preset-env": "7.9.6",
     "@rollup/plugin-babel": "5.0.0",
     "babel-jest": "26.0.1",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "jest": "26.0.1",
     "npm-run-all": "4.1.5",
     "rimraf": "3.0.2",
-    "rollup": "2.8.0",
+    "rollup": "2.8.1",
     "rollup-plugin-terser": "5.3.0"
   }
 }

--- a/rollup/rollup.config.js
+++ b/rollup/rollup.config.js
@@ -5,9 +5,11 @@ export const bundleNameGlobal = 'CodeBed';
 
 const config = {
 	input: `src/${bundleName}.js`,
-	plugins: [babel({
-		babelHelpers: 'bundled'
-	})],
+	plugins: [
+		babel({
+			babelHelpers: 'bundled'
+		})
+	],
 };
 
 export default config;

--- a/src/codebed.js
+++ b/src/codebed.js
@@ -7,17 +7,25 @@ import {
 } from './codepenUtil';
 import {
   copyAttributes,
-  createTemplateFromString
+  createTemplateFromString,
+  createIntersectionObserver
 } from './domUtil';
 
 // https://blog.codepen.io/documentation/embedded-pens/#the-embed-code-0
 const embedTemplateContent = `
-  <div class="${codepenEmbedClass}">
-    No CodePen connected
-  </div>
+  <div class="code-bed-no-pen">No CodePen connected</div>
 `;
 
 const templateContent = `
+  <style>
+    .code-bed-embed-container {
+      display: flex;
+      flex-direction: column;
+    }
+    .code-bed-embed-container .code-bed-no-pen {
+      margin: auto;
+    }
+  </style>
   <div>
     <div class="${codepenEmbedContainerClass}">
       ${embedTemplateContent}
@@ -37,24 +45,56 @@ export default class CodeBed extends HTMLElement {
   constructor() {
     super();
 
+    this.intersectionObserver =
+      createIntersectionObserver(intersections => this.onIntersectionUpdates(intersections));
+
     this.codepenEmbedContainerElem = null;
     this.codepenEmbedElem = null;
+  }
+  get codePenHeight() {
+    // Note: The default fallback 300, is the default height of
+    // CodePen embeds not specifying a height
+    return this.getAttribute('data-height') || '300';
+  }
+  get codePenSlugHash() {
+    return this.getAttribute('data-slug-hash') || '';
+  }
+  onIntersectionUpdates(intersections) {
+    const lastIntersectionRecord = intersections[intersections.length - 1];
+
+    if (lastIntersectionRecord?.isIntersecting) {
+        this.reloadCodePenEmbed();
+    }
+  }
+  resetEmbedContent() {
+    if (!this.codepenEmbedContainerElem) {
+      return;
+    }
+
+    this.codepenEmbedContainerElem.textContent = '';
+    this.codepenEmbedContainerElem.style.height = `${this.codePenHeight}px`;
+  
+    const embedTemplateClone = embedTemplate.content.cloneNode(true);
+    this.codepenEmbedContainerElem.appendChild(embedTemplateClone);
+    
+    this.codepenEmbedElem = this.codepenEmbedContainerElem.querySelector('div');
+
+    // If there is a code pen hash, add a special class
+    // including this hash to allow individual triggering
+    // or loading of it when it comes into view
+    if (this.codePenSlugHash) {
+      this.codepenEmbedElem.classList.add(`${codepenEmbedClass}-${this.codePenSlugHash}`);
+    }
+
+    copyAttributes(this, this.codepenEmbedElem, codepenEmbedAttributes);
   }
   reloadCodePenEmbed() {
     if (!this.codepenEmbedContainerElem) {
       return;
     }
 
-    this.codepenEmbedContainerElem.textContent = '';
-  
-    const embedTemplateClone = embedTemplate.content.cloneNode(true);
-    this.codepenEmbedContainerElem.appendChild(embedTemplateClone);
-    
-    this.codepenEmbedElem = this.codepenEmbedContainerElem.querySelector(`.${codepenEmbedClass}`);
-    copyAttributes(this, this.codepenEmbedElem, codepenEmbedAttributes);
-
     loadCodePenEmbedScript()
-      .then(triggerCodePenEmbedReload)
+      .then(() => triggerCodePenEmbedReload(this.codePenSlugHash))
       // Would probably want to handle this better later
       .catch(err => {
         this.codepenEmbedElem.textContent = 'An error occurred while loading the CodePen';
@@ -71,10 +111,33 @@ export default class CodeBed extends HTMLElement {
     this.appendChild(templateClone);
 
     this.codepenEmbedContainerElem = this.querySelector(`.${codepenEmbedContainerClass}`);
+    this.resetEmbedContent();
+
+    /*
+      If the intersection observer API is supported then we will
+      let that trigger the loading of the CodePen embed, when the
+      CodePen embed container elem is brought into view.
+
+      If the intersection observer API is not supported, then we will
+      immediately load the CodePen.
+    */
+    if (this.intersectionObserver) {
+      this.intersectionObserver.observe(this.codepenEmbedContainerElem);
+    } else {
+      this.reloadCodePenEmbed();
+    }
+  }
+  attributeChangedCallback(name, oldValue, newValue) {
+    this.resetEmbedContent();
     this.reloadCodePenEmbed();
   }
-  attributeChangedCallback() {
-    this.reloadCodePenEmbed();
+  disconnectedCallback() {
+    if (this.intersectionObserver) {
+      this.intersectionObserver.unobserve(this.codepenEmbedContainerElem);
+    }
+
+    this.codepenEmbedContainerElem = null;
+    this.codepenEmbedElem = null;
   }
 }
 

--- a/src/codebed.js
+++ b/src/codebed.js
@@ -83,7 +83,9 @@ export default class CodeBed extends HTMLElement {
     // including this hash to allow individual triggering
     // or loading of it when it comes into view
     if (this.codePenSlugHash) {
-      this.codepenEmbedElem.classList.add(`${codepenEmbedClass}-${this.codePenSlugHash}`);
+      const codePenSlugHash = this.codePenSlugHash ?
+        `-${this.codePenSlugHash}` : '';
+      this.codepenEmbedElem.classList.add(`${codepenEmbedClass}${codePenSlugHash}`);
     }
 
     copyAttributes(this, this.codepenEmbedElem, codepenEmbedAttributes);

--- a/src/codepenUtil.js
+++ b/src/codepenUtil.js
@@ -29,12 +29,12 @@ export const codepenEmbedAttributes = Object.freeze([
     "data-preview"
 ]);
 
-export function triggerCodePenEmbedReload() {
+export function triggerCodePenEmbedReload(slugHash) {
     if (!hasCodePenEmbedScript()) {
         return;
     }
 
-    window.__CPEmbed(`.${codepenEmbedClass}`);
+    window.__CPEmbed(`.${codepenEmbedClass}${slugHash ? `-${slugHash}` : ''}`);
 }
 
 export function loadCodePenEmbedScript() {

--- a/src/domUtil.js
+++ b/src/domUtil.js
@@ -14,15 +14,14 @@ export function createTemplateFromString(templateHTMLString) {
     return template;
 }
 
-// const defaultIntersectionObeserverOptions = Object.freeze({
-//     rootMargin: '0px',
-//     threshold: 0.25
-// });
+const defaultIntersectionObeserverOptions = Object.freeze({
+    rootMargin: '20px',
+});
 
 // https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API
 export function createIntersectionObserver(observerCallback) {
     if (typeof IntersectionObserver !== 'function') {
         return null;
     }
-    return new IntersectionObserver(observerCallback);
+    return new IntersectionObserver(observerCallback, defaultIntersectionObeserverOptions);
 }

--- a/src/domUtil.js
+++ b/src/domUtil.js
@@ -13,3 +13,16 @@ export function createTemplateFromString(templateHTMLString) {
     template.innerHTML = templateHTMLString;
     return template;
 }
+
+// const defaultIntersectionObeserverOptions = Object.freeze({
+//     rootMargin: '0px',
+//     threshold: 0.25
+// });
+
+// https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API
+export function createIntersectionObserver(observerCallback) {
+    if (typeof IntersectionObserver !== 'function') {
+        return null;
+    }
+    return new IntersectionObserver(observerCallback);
+}


### PR DESCRIPTION
If available, make use of the [Intersection Observer API](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API) to detect if a `code-bed` web component is in view.

If it is in view, or within a small threshold, the CodePen embed script will be downloaded if not already done so, and then the CodePen itself will be instantiated.

If it is not in view, then the web component template will be readied, but the CodePen itself will not be loaded.

If the Intersection Observer API is not supported, then the CodePen will always be loaded.